### PR TITLE
Making minter and burner explicit, so that they can be contracts

### DIFF
--- a/contracts/MagicSeries.sol
+++ b/contracts/MagicSeries.sol
@@ -13,6 +13,7 @@ contract MagicSeries is ERC1155 {
   using Address for address;
   using Strings for uint256;
 
+  // @dev Emitted when a new series is created
   event SeriesCreated(
     uint256 indexed seriesId,
     address indexed creator,
@@ -23,10 +24,13 @@ contract MagicSeries is ERC1155 {
     address burner
   );
 
+  // @dev Emitted when the minter for a series is updated
   event SeriesMinterUpdated(uint256 indexed seriesId, address indexed minter);
 
+  // @dev Emitted when the burner for a series is updated
   event SeriesBurnerUpdated(uint256 indexed seriesId, address indexed burner);
 
+  // @dev Emitted when the metadata for a series is updated
   event SeriesMetadataUpdated(uint256 indexed seriesId, string name, string description, string image);
 
   error NotTheSeriesCreator();
@@ -53,26 +57,33 @@ contract MagicSeries is ERC1155 {
     address burner;
   }
 
+  // @dev Series data
   mapping(uint256 => Series) internal _series;
+
+  // @dev Series ids by creator
   mapping(address => uint256[]) private _seriesByCreator;
 
+  // @dev checks that only the series' creator can do something
   modifier onlySeriesCreator(uint256 seriesId) {
     if (_msgSender() != _series[seriesId].creator) revert NotTheSeriesCreator();
     _;
   }
 
+  // @dev checks that only the series' minter can do something
   modifier onlySeriesMinter(uint256 seriesId) {
     if (address(0) == _series[seriesId].minter) revert MintingHasEnded();
     if (_msgSender() != _series[seriesId].minter) revert NotTheSeriesMinter();
     _;
   }
 
+  // @dev checks that only the series' burner can do something
   modifier onlySeriesBurner(uint256 seriesId) {
     if (address(0) == _series[seriesId].burner) revert NotBurnable();
     if (_msgSender() != _series[seriesId].burner) revert NotTheSeriesBurner();
     _;
   }
 
+  // @dev checks that the series exists
   modifier seriesExists(uint256 seriesId) {
     if (_series[seriesId].creator == address(0)) revert SeriesNotFound();
     _;
@@ -80,6 +91,10 @@ contract MagicSeries is ERC1155 {
 
   // solhint-disable-next-line
   constructor() ERC1155("") {
+    // The Cruna metadata API will get the data from the smart contract and format them
+    // in the metadata format used by major players. For better performances, the metadata
+    // are cached. Look at meta.cruna.cc to know how to force the refresh of the cache for
+    // a specific series.
     _setURI(string(abi.encodePacked("https://meta.cruna.cc/magic-series/", block.chainid.toString(), "/{id}")));
   }
 

--- a/contracts/MagicSeries.sol
+++ b/contracts/MagicSeries.sol
@@ -13,12 +13,34 @@ contract MagicSeries is ERC1155 {
   using Address for address;
   using Strings for uint256;
 
+  event SeriesCreated(
+    uint256 indexed seriesId,
+    address indexed creator,
+    string name,
+    string description,
+    string image,
+    address minter,
+    address burner
+  );
+
+  event SeriesMinterUpdated(uint256 indexed seriesId, address indexed minter);
+
+  event SeriesBurnerUpdated(uint256 indexed seriesId, address indexed burner);
+
+  event SeriesMetadataUpdated(uint256 indexed seriesId, string name, string description, string image);
+
   error NotTheSeriesCreator();
+  error NotTheSeriesMinter();
+  error NotTheSeriesBurner();
   error InconsistentArrays();
   error SeriesNotFound();
+  error MintingHasEnded();
+  error MinterAlreadySet();
   error NotBurnable();
+  error BurnerAlreadySet();
 
   uint256 private _nextSeriesId;
+  string public version = "0.1.0";
 
   // this is relatively expensive, but its cost will reduce abuses
   struct Series {
@@ -27,7 +49,8 @@ contract MagicSeries is ERC1155 {
     string name;
     string description;
     string image;
-    bool burnable;
+    address minter;
+    address burner;
   }
 
   mapping(uint256 => Series) internal _series;
@@ -38,8 +61,15 @@ contract MagicSeries is ERC1155 {
     _;
   }
 
-  modifier onlyBurnable(uint256 seriesId) {
-    if (!_series[seriesId].burnable) revert NotBurnable();
+  modifier onlySeriesMinter(uint256 seriesId) {
+    if (address(0) == _series[seriesId].minter) revert MintingHasEnded();
+    if (_msgSender() != _series[seriesId].minter) revert NotTheSeriesMinter();
+    _;
+  }
+
+  modifier onlySeriesBurner(uint256 seriesId) {
+    if (address(0) == _series[seriesId].burner) revert NotBurnable();
+    if (_msgSender() != _series[seriesId].burner) revert NotTheSeriesBurner();
     _;
   }
 
@@ -50,58 +80,150 @@ contract MagicSeries is ERC1155 {
 
   // solhint-disable-next-line
   constructor() ERC1155("") {
-    _setURI(string(abi.encodePacked("https://meta.cruna.cc/magic-bin/", block.chainid.toString(), "/{id}")));
+    _setURI(string(abi.encodePacked("https://meta.cruna.cc/magic-series/", block.chainid.toString(), "/{id}")));
   }
 
+  /*
+    @dev Creates a new series
+    @param name The name of the series.
+    @param description The description of the series
+    @param image The image of the series
+    @param minter The address that can mint tokens of the series
+     The minter would ideally be a smart contract, but it is not mandatory.
+     If minter is address(0), the owner of the series is the minter.
+    @param burner The address that can burn tokens of the series
+     The burner should be a smart contract, but it is not mandatory.
+     The idea is that, for example, the tokens in the series can be
+     burned to swap there with other tokens.
+     If the burner is address(0), the series is not burnable.
+     For clarity, if the burner is not set at creation, it cannot be set later.
+  */
   function createSeries(
     string memory name,
     string memory description,
     string memory image,
-    bool burnable
+    address minter,
+    address burner
   ) public {
+    if (minter == address(0)) minter = _msgSender();
     _series[++_nextSeriesId] = Series({
       createdAtBlock: block.number,
       creator: _msgSender(),
       name: name,
       description: description,
       image: image,
-      burnable: burnable
+      minter: minter,
+      burner: burner
     });
     _seriesByCreator[_msgSender()].push(_nextSeriesId);
+    emit SeriesCreated(_nextSeriesId, _msgSender(), name, description, image, minter, burner);
   }
 
-  function _arr(uint256 elem) internal pure returns (uint256[] memory) {
+  /*
+    @dev Update image and burner address of a series
+    @param seriesId The id of the series
+    @param name The name of the series, if not empty, it will be applied
+    @param description The description of the series, if not empty, it will be applied
+    @param image The image of the series, if not empty, it will be applied
+  */
+  function updateSeriesMetadata(
+    uint256 seriesId,
+    string memory name,
+    string memory description,
+    string memory image
+  ) external onlySeriesCreator(seriesId) {
+    if (bytes(name).length != 0) _series[seriesId].name = name;
+    if (bytes(description).length != 0) _series[seriesId].description = description;
+    if (bytes(image).length != 0) _series[seriesId].image = image;
+    emit SeriesMetadataUpdated(seriesId, name, description, image);
+  }
+
+  /*
+    @dev Update the minter address of a series
+    @param seriesId The id of the series
+    @param minter The address that can mint tokens of the series.
+      If the new minter is address(0), the series won't be mintable anymore.
+  */
+  function updateSeriesMinter(uint256 seriesId, address minter) external onlySeriesCreator(seriesId) {
+    if (_series[seriesId].minter == address(0)) revert MintingHasEnded();
+    if (_series[seriesId].minter == minter) revert MinterAlreadySet();
+    _series[seriesId].minter = minter;
+    emit SeriesMinterUpdated(seriesId, minter);
+  }
+
+  /*
+    @dev Update the burner address of a series
+    @param seriesId The id of the series
+    @param burner The address that can burn tokens of the series.
+      It will revert if the series was not burnable in the first instance.
+      If the new address is address(0), the series will not be burnable anymore.
+  */
+  function updateSeriesBurner(uint256 seriesId, address burner) external onlySeriesCreator(seriesId) {
+    if (_series[seriesId].burner == address(0)) revert NotBurnable();
+    if (_series[seriesId].burner == burner) revert BurnerAlreadySet();
+    _series[seriesId].burner = burner;
+    emit SeriesBurnerUpdated(seriesId, burner);
+  }
+
+  /*
+    @dev Private function that convert a uint to a uint[]
+    @param elem The single element
+    @return An array containing the single element
+  */
+  function _arr(uint256 elem) private pure returns (uint256[] memory) {
     uint256[] memory arr = new uint256[](1);
     arr[0] = elem;
     return arr;
   }
 
+  /*
+    @dev Mint a token of a series
+    @param seriesId The id of the series
+    @param recipients An array of addresses that will receive the token
+    @param amounts An array of amounts of tokens to mint
+  */
   function mint(
     uint256 seriesId,
     address[] memory recipients,
     uint256[] memory amounts
-  ) public onlySeriesCreator(seriesId) {
+  ) public onlySeriesMinter(seriesId) {
     if (recipients.length != amounts.length) revert InconsistentArrays();
     for (uint256 i = 0; i < recipients.length; i++) {
       _mintBatch(recipients[i], _arr(seriesId), _arr(amounts[i]), "");
     }
   }
 
+  /*
+    @dev Burn tokens of a series
+    @param seriesId The id of the series
+    @param recipients An array of addresses that will receive the token
+    @param amounts An array of amounts of tokens to burn
+  */
   function burn(
     uint256 seriesId,
     address[] memory recipients,
     uint256[] memory amounts
-  ) public onlySeriesCreator(seriesId) onlyBurnable(seriesId) {
+  ) public onlySeriesBurner(seriesId) {
     if (recipients.length != amounts.length) revert InconsistentArrays();
     for (uint256 i = 0; i < recipients.length; i++) {
       _burn(recipients[i], seriesId, amounts[i]);
     }
   }
 
+  /*
+    @dev Get the series ids created by an address
+    @param creator The address of the creator
+    @return An array of series ids
+  */
   function seriesByCreator(address creator) public view returns (uint256[] memory) {
     return _seriesByCreator[creator];
   }
 
+  /*
+    @dev Get the series ids created by an address with their names
+    @param creator The address of the creator
+    @return An array of series ids with their names
+  */
   function seriesByCreatorWithNames(address creator) public view returns (string[] memory) {
     uint256[] memory seriesIds = _seriesByCreator[creator];
     string[] memory seriesNames = new string[](seriesIds.length);
@@ -112,10 +234,20 @@ contract MagicSeries is ERC1155 {
     return seriesNames;
   }
 
+  /*
+    @dev Get the series created by an address
+    @param creator The address of the creator
+    @return An array of Series structures
+  */
   function series(uint256 seriesId) public view seriesExists(seriesId) returns (Series memory) {
     return _series[seriesId];
   }
 
+  /*
+    @dev Converts the a series to a JSON string
+    @param seriesId The id of the series
+    @return A JSON string representing the series
+  */
   function metadata(uint256 seriesId) public view seriesExists(seriesId) returns (string memory) {
     return
       string(
@@ -130,11 +262,14 @@ contract MagicSeries is ERC1155 {
           '","image":"',
           _series[seriesId].image,
           // solhint-disable-next-line quotes
-          '","burnable":',
-          _series[seriesId].burnable ? "true" : "false",
-          // solhint-disable-next-line quotes
-          ',"creator":"',
+          '","creator":"',
           uint256(uint160(_series[seriesId].creator)).toHexString(),
+          // solhint-disable-next-line quotes
+          '","minter":"',
+          uint256(uint160(_series[seriesId].minter)).toHexString(),
+          // solhint-disable-next-line quotes
+          '","burner":"',
+          uint256(uint160(_series[seriesId].burner)).toHexString(),
           // solhint-disable-next-line quotes
           '","seriesId":',
           seriesId.toString(),

--- a/scripts/deploy-series.js
+++ b/scripts/deploy-series.js
@@ -1,7 +1,7 @@
 require("dotenv").config();
 const hre = require("hardhat");
 const ethers = hre.ethers;
-const {getCurrentTimestamp} = require("hardhat/internal/hardhat-network/provider/utils/getCurrentTimestamp");
+
 const DeployUtils = require("./lib/DeployUtils");
 let deployUtils;
 

--- a/test/MagicSeries.test.js
+++ b/test/MagicSeries.test.js
@@ -1,14 +1,14 @@
 const {expect, assert} = require("chai");
 const DeployUtils = require("../scripts/lib/DeployUtils");
-const {getBlockNumber} = require("./helpers");
+const {getBlockNumber, addr0} = require("./helpers");
 
 describe("MagicSeries", function () {
   let deployUtils = new DeployUtils(ethers);
-  let owner, sullof, twitter, bob, alice, fred, john, jane, mark;
+  let owner, sullof, twitter, bob, alice, fred, john, minter1, burner1, minter2;
   let magicSeries;
 
   before(async function () {
-    [owner, sullof, twitter, bob, alice, fred, john, jane, mark] = await ethers.getSigners();
+    [owner, sullof, twitter, bob, alice, fred, john, minter1, burner1, minter2] = await ethers.getSigners();
   });
 
   async function initAndDeploy() {
@@ -22,7 +22,9 @@ describe("MagicSeries", function () {
   it("should create two series and verify their ID", async function () {
     const blockNumber = await getBlockNumber();
 
-    await magicSeries.connect(sullof).createSeries("Sullof", "A Series for Sullof", "https://twitter.com/sullof/photo", true);
+    await magicSeries
+      .connect(sullof)
+      .createSeries("Sullof", "A Series for Sullof", "https://twitter.com/sullof/photo", minter1.address, burner1.address);
 
     let sullofSeries = await magicSeries.seriesByCreator(sullof.address);
     expect(sullofSeries[0].toNumber()).to.equal(1);
@@ -32,32 +34,38 @@ describe("MagicSeries", function () {
 
     await magicSeries
       .connect(twitter)
-      .createSeries("Twitter", "A Series for Twitter", "https://twitter.com/twitter/photo", false);
+      .createSeries("Twitter", "A Series for Twitter", "https://twitter.com/twitter/photo", addr0, addr0);
     await magicSeries
       .connect(twitter)
-      .createSeries("Twitter2", "A 2nd Series for Twitter", "https://twitter.com/twitterdev/photo", false);
+      .createSeries("Twitter2", "A 2nd Series for Twitter", "https://twitter.com/twitterdev/photo", minter2.address, addr0);
     twitterSeries = await magicSeries.seriesByCreator(twitter.address);
     expect(twitterSeries.length).to.equal(2);
 
+    await expect(magicSeries.connect(sullof).mint(1, [bob.address, alice.address, fred.address], [24, 40, 36])).revertedWith(
+      "NotTheSeriesMinter()"
+    );
+
     // distribute tokens
-    await magicSeries.connect(sullof).mint(1, [bob.address, alice.address, fred.address], [24, 40, 36]);
+    await magicSeries.connect(minter1).mint(1, [bob.address, alice.address, fred.address], [24, 40, 36]);
     expect(await magicSeries.balanceOf(bob.address, 1)).to.equal(24);
     expect(await magicSeries.balanceOf(alice.address, 1)).to.equal(40);
     expect(await magicSeries.balanceOf(fred.address, 1)).to.equal(36);
 
-    await magicSeries.connect(sullof).mint(1, [bob.address, john.address], [24, 120]);
+    await magicSeries.connect(minter1).mint(1, [bob.address, john.address], [24, 120]);
     expect(await magicSeries.balanceOf(bob.address, 1)).to.equal(48);
     expect(await magicSeries.balanceOf(john.address, 1)).to.equal(120);
 
-    expect(magicSeries.connect(sullof).mint(1, [bob.address], [24, 120])).revertedWith("InconsistentArrays()");
+    expect(magicSeries.connect(minter1).mint(1, [bob.address], [24, 120])).revertedWith("InconsistentArrays()");
 
-    const metadata = JSON.parse(await magicSeries.metadata(1));
+    let metadata = JSON.parse(await magicSeries.metadata(1));
 
     // console.log(metadata);
 
     expect(metadata.name).to.equal("Sullof");
     expect(metadata.description).to.equal("A Series for Sullof");
     expect(metadata.image).to.equal("https://twitter.com/sullof/photo");
+    expect(metadata.minter).to.equal(minter1.address.toLowerCase());
+    expect(metadata.burner).to.equal(burner1.address.toLowerCase());
     expect(metadata.creator).to.equal(sullof.address.toLowerCase());
     expect(metadata.createdAtBlock > blockNumber).to.be.true;
 
@@ -66,8 +74,45 @@ describe("MagicSeries", function () {
     expect(seriesWithNames[0]).to.equal("2 Twitter");
     expect(seriesWithNames[1]).to.equal("3 Twitter2");
 
-    await magicSeries.connect(sullof).burn(1, [bob.address, john.address], [10, 120]);
+    await magicSeries.connect(burner1).burn(1, [bob.address, john.address], [10, 120]);
     expect(await magicSeries.balanceOf(bob.address, 1)).to.equal(38);
     expect(await magicSeries.balanceOf(john.address, 1)).to.equal(0);
+
+    // update metadata
+
+    await expect(
+      magicSeries
+        .connect(sullof)
+        .updateSeriesMetadata(1, "Sullof2", "A Series for Sullof2", "https://twitter.com/sullof2/photo")
+    )
+      .emit(magicSeries, "SeriesMetadataUpdated")
+      .withArgs(1, "Sullof2", "A Series for Sullof2", "https://twitter.com/sullof2/photo");
+
+    metadata = JSON.parse(await magicSeries.metadata(1));
+
+    // console.log(metadata);
+
+    expect(metadata.name).to.equal("Sullof2");
+    expect(metadata.description).to.equal("A Series for Sullof2");
+    expect(metadata.image).to.equal("https://twitter.com/sullof2/photo");
+
+    // end minting
+
+    await expect(magicSeries.connect(sullof).updateSeriesMinter(1, addr0))
+      .emit(magicSeries, "SeriesMinterUpdated")
+      .withArgs(1, addr0);
+
+    metadata = JSON.parse(await magicSeries.metadata(1));
+    expect(metadata.minter).to.equal("0x00");
+
+    await expect(magicSeries.connect(minter1).mint(1, [bob.address, alice.address, fred.address], [24, 40, 36])).revertedWith(
+      "MintingHasEnded()"
+    );
+
+    await expect(magicSeries.connect(sullof).updateSeriesBurner(1, addr0))
+      .emit(magicSeries, "SeriesBurnerUpdated")
+      .withArgs(1, addr0);
+
+    await expect(magicSeries.connect(burner1).burn(1, [bob.address, john.address], [10, 120])).revertedWith("NotBurnable()");
   });
 });


### PR DESCRIPTION
When a series is used to track a contribution, it is very likely that at some moment, that the contribution will convert to some other assets. This process, most likely, will be executed by a contract. Same, most likely, can happen when minting series id. In this new version the metadata, minter and burner are updatable.
To end the minting of a series, the minter can be set to address(0).
A burner must be set from the very beginning, in order to have a burnable series. Only if it is not address(0), the burner can be updated. When set to address(0) the series is no more burnable.